### PR TITLE
Fix createHiddenInputs

### DIFF
--- a/app/assets/javascripts/active_admin/select2/select2.js
+++ b/app/assets/javascripts/active_admin/select2/select2.js
@@ -53,10 +53,15 @@ $(function() {
     var id = item.attr('id');
     var name = item.attr('name').replace(/^ui_/, '');
     $('.hidden_' + id).remove();
-    for (var i = 0; i < values.length; i++) {
-      var value = values[i];
-      var hiddenId = 'hidden_' + id + '_' + (i+1);
-      item.append('<input type="hidden" id="' + hiddenId + '" class="hidden_' + id + '" name="' + name + '" value="' + value + '" />');
+
+    if (values.length === 0) {
+      item.append('<input type="hidden" class="hidden_' + id + '" name="' + name + '" />');
+    } else {
+      for (var i = 0; i < values.length; i++) {
+        var value = values[i];
+        var hiddenId = 'hidden_' + id + '_' + (i+1);
+        item.append('<input type="hidden" id="' + hiddenId + '" class="hidden_' + id + '" name="' + name + '" value="' + value + '" />');
+      }
     }
   };
 


### PR DESCRIPTION
Hey guys!

Right now we're not creating hidden fields when the select field has no value, so it's hard to check if the user is trying to delete all entries from the specific select field. It would be better to create an empty hidden field so we can receive `['']` in the backend and treat it accordingly.

@chute/backend (since it's related to ActiveAdmin)